### PR TITLE
Make payee merchant code as required field | Fix payment failure

### DIFF
--- a/EasyUpiPayment/build.gradle
+++ b/EasyUpiPayment/build.gradle
@@ -51,12 +51,12 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation "androidx.core:core-ktx:1.3.1"
+    implementation "androidx.core:core-ktx:1.3.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.annotation:annotation:1.1.0'
 
     // Testing
-    testImplementation 'junit:junit:4.13'
+    testImplementation 'junit:junit:4.13.1'
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation 'org.mockito:mockito-core:3.5.0'
 

--- a/EasyUpiPayment/build.gradle
+++ b/EasyUpiPayment/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'org.jetbrains.dokka'
 
-version = "3.0.0"
+version = "3.0.1"
 
 android {
     compileSdkVersion 30

--- a/EasyUpiPayment/src/main/java/com/shreyaspatil/EasyUpiPayment/EasyUpiPayment.kt
+++ b/EasyUpiPayment/src/main/java/com/shreyaspatil/EasyUpiPayment/EasyUpiPayment.kt
@@ -209,7 +209,7 @@ class EasyUpiPayment constructor(
 				currency = "INR",
 				vpa = payeeVpa!!,
 				name = payeeName!!,
-				payeeMerchantCode = payeeMerchantCode,
+				payeeMerchantCode = payeeMerchantCode!!,
 				txnId = transactionId!!,
 				txnRefId = transactionRefId!!,
 				description = description!!,
@@ -233,8 +233,8 @@ class EasyUpiPayment constructor(
 				}
 			}
 
-			payeeMerchantCode?.let {
-				check(it.isNotBlank()) { "Merchant Code Should be Valid!" }
+			payeeMerchantCode?.run {
+				checkNotNull(this) { "Payee Merchant Code Should be Valid!" }
 			}
 
 			transactionId.run {

--- a/EasyUpiPayment/src/main/java/com/shreyaspatil/EasyUpiPayment/model/Payment.kt
+++ b/EasyUpiPayment/src/main/java/com/shreyaspatil/EasyUpiPayment/model/Payment.kt
@@ -6,7 +6,7 @@ data class Payment(
 	var currency: String,
 	var vpa: String,
 	var name: String,
-	var payeeMerchantCode: String?,
+	var payeeMerchantCode: String,
 	var txnId: String,
 	var txnRefId: String,
 	var description: String,

--- a/EasyUpiPayment/src/main/java/com/shreyaspatil/EasyUpiPayment/ui/PaymentUiActivity.kt
+++ b/EasyUpiPayment/src/main/java/com/shreyaspatil/EasyUpiPayment/ui/PaymentUiActivity.kt
@@ -32,7 +32,7 @@ class PaymentUiActivity : AppCompatActivity() {
 				appendQueryParameter("pa", vpa)
 				appendQueryParameter("pn", name)
 				appendQueryParameter("tid", txnId)
-				payeeMerchantCode?.let { appendQueryParameter("mc", it) }
+				appendQueryParameter("mc", payeeMerchantCode)
 				appendQueryParameter("tr", txnRefId)
 				appendQueryParameter("tn", description)
 				appendQueryParameter("am", amount)
@@ -45,9 +45,7 @@ class PaymentUiActivity : AppCompatActivity() {
 			data = paymentUri
 
 			// Check for Default package
-			payment.defaultPackage?.let {
-				`package` = it
-			}
+			payment.defaultPackage?.let { `package` = it }
 		}
 
 		// Show Dialog to user

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,17 +27,17 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "androidx.core:core-ktx:1.3.1"
+    implementation "androidx.core:core-ktx:1.3.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
-    implementation 'com.google.android.material:material:1.2.0'
-    testImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'com.google.android.material:material:1.2.1'
+    testImplementation 'junit:junit:4.13.1'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
     // EasyUpiPayment Library
-    implementation 'com.shreyaspatil:EasyUpiPayment:3.0.0'
+    implementation 'com.shreyaspatil:EasyUpiPayment:3.0.1'
 
 //    implementation project(path: ':EasyUpiPayment')
 }

--- a/app/src/main/java/com/example/easyupipayment/java/MainActivity.java
+++ b/app/src/main/java/com/example/easyupipayment/java/MainActivity.java
@@ -30,6 +30,7 @@ public class MainActivity extends AppCompatActivity implements PaymentStatusList
 
     private EditText fieldPayeeVpa;
     private EditText fieldPayeeName;
+    private EditText fieldPayeeMerchantCode;
     private EditText fieldTransactionId;
     private EditText fieldTransactionRefId;
     private EditText fieldDescription;
@@ -54,6 +55,7 @@ public class MainActivity extends AppCompatActivity implements PaymentStatusList
 
         fieldPayeeVpa = findViewById(R.id.field_vpa);
         fieldPayeeName = findViewById(R.id.field_name);
+        fieldPayeeMerchantCode = findViewById(R.id.field_payee_merchant_code);
         fieldTransactionId = findViewById(R.id.field_transaction_id);
         fieldTransactionRefId = findViewById(R.id.field_transaction_ref_id);
         fieldDescription = findViewById(R.id.field_description);
@@ -69,6 +71,7 @@ public class MainActivity extends AppCompatActivity implements PaymentStatusList
     private void pay() {
         String payeeVpa = fieldPayeeVpa.getText().toString();
         String payeeName = fieldPayeeName.getText().toString();
+        String payeeMerchantCode = fieldPayeeMerchantCode.getText().toString();
         String transactionId = fieldTransactionId.getText().toString();
         String transactionRefId = fieldTransactionRefId.getText().toString();
         String description = fieldDescription.getText().toString();
@@ -108,6 +111,7 @@ public class MainActivity extends AppCompatActivity implements PaymentStatusList
                 .setPayeeName(payeeName)
                 .setTransactionId(transactionId)
                 .setTransactionRefId(transactionRefId)
+                .setPayeeMerchantCode(payeeMerchantCode)
                 .setDescription(description)
                 .setAmount(amount);
         // END INITIALIZATION

--- a/app/src/main/java/com/example/easyupipayment/kotlin/MainActivity.kt
+++ b/app/src/main/java/com/example/easyupipayment/kotlin/MainActivity.kt
@@ -37,6 +37,7 @@ class MainActivity : AppCompatActivity(), PaymentStatusListener {
 		val payeeName = field_name.text.toString()
 		val transactionId = field_transaction_id.text.toString()
 		val transactionRefId = field_transaction_ref_id.text.toString()
+		val payeeMerchantCode = field_payee_merchant_code.text.toString()
 		val description = field_description.text.toString()
 		val amount = field_amount.text.toString()
 		val paymentAppChoice = radioAppChoice
@@ -59,6 +60,7 @@ class MainActivity : AppCompatActivity(), PaymentStatusListener {
 				this.payeeName = payeeName
 				this.transactionId = transactionId
 				this.transactionRefId = transactionRefId
+				this.payeeMerchantCode = payeeMerchantCode
 				this.description = description
 				this.amount = amount
 			}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,10 +3,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
+    <LinearLayout xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical"
         android:padding="16dp"
         tools:context=".java.MainActivity">
@@ -22,6 +21,12 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="Payee Name" />
+
+        <EditText
+            android:id="@+id/field_payee_merchant_code"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Payee Merchant Code" />
 
         <EditText
             android:id="@+id/field_transaction_id"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
 
         // Required plugins added to classpath to facilitate pushing to Jcenter/Bintray
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Welcome! If you want to integrate UPI payments in Android app then you're at rig
 - This library is based on Android Intent based operations.
 - Whenever payment is initiated, it simply sends the `Intent` to the UPI apps installed on device.
 - When transaction is done, response is returned from library.
+- Payment will be only processed when payee is having a **valid merchant account of UPI**. Otherwise, payment won't be successful. This _won't work for general UPI payee user_.
 
 ## Flow
 

--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -4,6 +4,11 @@ You can see [GitHub releases](https://github.com/PatilShreyas/EasyUpiPayment-And
 
 ---
 
+## _v3.0.1_ (2020-11-15)
+
+Make Payee merchant code as required field. (This will be required parameter from this version as UPI payment will be only processed if payee account is a valid **merchant account**.)
+If this parameter is not provided with _EasyUpiPayment_ `Builder` then it'll throw `IllegalStateException`.
+
 ## _v3.0.0_ (2020-09-04)
 
 - Moved to [symantic versioning](https://semver.org/) from this release.

--- a/docs/pages/setup-payment-info.md
+++ b/docs/pages/setup-payment-info.md
@@ -14,6 +14,7 @@ To setup payment, make sure you're implementing in `Activity`. It's recommended 
 val easyUpiPayment = EasyUpiPayment(this) {
     this.payeeVpa = "example@upi"
     this.payeeName = "Narendra Modi"
+    this.payeeMerchantCode = "12345"
     this.transactionId = "T2020090212345"
     this.transactionRefId = "T2020090212345"
     this.description = "Description"
@@ -29,6 +30,7 @@ Use `EasyUpiPayment.Builder` to set payment information.
 EasyUpiPayment.Builder builder = new EasyUpiPayment.Builder(this)
         .setPayeeVpa("example@vpa")
         .setPayeeName("Narendra Modi")
+        .setPayeeMerchantCode("12345")
         .setTransactionId("T2020090212345")
         .setTransactionRefId("T2020090212345")
         .setDescription("Description")
@@ -61,6 +63,12 @@ EasyUpiPayment easyUpiPayment = builder.build();
     <td>It takes VPA address of payee for e.g. <span style="font-weight:600">shreyas@upi</span></td>
   </tr>
   <tr>
+    <td><code>payeeMerchantCode</code></td>
+    <td><code>setPayeeMerchantCode()</code></td>
+    <td>✔️</td>
+    <td>Payee Merchant code. This should be valid.</td>
+  </tr>
+  <tr>
     <td><code>transactionId</code></td>
     <td><code>setTransactionId()</code></td>
     <td>✔️</td>
@@ -85,12 +93,6 @@ EasyUpiPayment easyUpiPayment = builder.build();
     <td>It takes the amount in String decimal format (xx.xx) to be paid. <br>For e.g. 90.88 will pay <span style="font-style:italic">Rs. 90.88.</span></td>
   </tr>
   <tr>
-    <td><code>payeeMerchantCode</code></td>
-    <td><code>setPayeeMerchantCode()</code></td>
-    <td>❌</td>
-    <td>Payee Merchant code if present it should be passed.</td>
-  </tr>
-  <tr>
     <td>❌No need❌</td>
     <td><code>build()<code></td>
     <td>✔️</td>
@@ -98,4 +100,5 @@ EasyUpiPayment easyUpiPayment = builder.build();
   </tr>
 </table>
 
-!> If any of the above field is initiated using invalid values then `Builder` will throw `IllegalStateException` with appropriate message. Make sure you're handling it.
+!> _Payee should be a valid merchant account holder otherwise transaction won't be completed._
+If any of the above field is initiated using invalid values then `Builder` will throw `IllegalStateException` with appropriate message. Make sure you're handling it.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Oct 17 21:39:46 IST 2020
+#Sun Nov 15 16:13:43 IST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
## Summary

Made `payeeMerchantCode` as required field as a required field. This fixes payment failure.

***Note:*** _Now onwards, payment will be only processed for the payee having a valid merchant account. This won't work for normal UPI users._

Fixes: #67 

---

Thanks to @abhitulse for letting us know about the solution of the issue! 😃 