### PR TITLE
Release v3.0.3

### DIFF
--- a/EasyUpiPayment/build.gradle
+++ b/EasyUpiPayment/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
     // Testing
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation 'org.mockito:mockito-core:3.5.0'
 
@@ -68,7 +68,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'org.mockito:mockito-core:3.5.0'
-    androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito-inline-extended:2.28.0'
+    androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito-inline-extended:2.28.1'
 }
 
 dokkaHtml.configure {

--- a/EasyUpiPayment/src/main/AndroidManifest.xml
+++ b/EasyUpiPayment/src/main/AndroidManifest.xml
@@ -3,10 +3,24 @@
     package="dev.shreyaspatil.easyupipayment">
 
     <queries>
+        <!-- View Intent for UPI apps -->
         <intent>
             <action android:name="android.intent.action.VIEW" />
             <data android:scheme="upi" />
         </intent>
+
+        <!-- Chooser Intent for UPI apps -->
+        <intent>
+            <action android:name="android.intent.action.CHOOSER" />
+            <data android:scheme="upi" />
+        </intent>
+
+        <!-- Package Specific UPI Apps -->
+        <package android:name="in.amazon.mShop.android.shopping" />
+        <package android:name="in.org.npci.upiapp" />
+        <package android:name="com.google.android.apps.nbu.paisa.user" />
+        <package android:name="com.phonepe.app" />
+        <package android:name="net.one97.paytm" />
     </queries>
 
     <application>

--- a/EasyUpiPayment/src/main/AndroidManifest.xml
+++ b/EasyUpiPayment/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <queries>
         <intent>
-            <action android:name="android.intent.action.CHOOSER" />
+            <action android:name="android.intent.action.VIEW" />
             <data android:scheme="upi" />
         </intent>
     </queries>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Easy UPI Payment - Android Library 📱💳
 
-![Bintray](https://img.shields.io/bintray/v/patilshreyas/maven/com.shreyaspatil:EasyUpiPayment?style=flat-square)
+![Maven Central](https://img.shields.io/maven-central/v/dev.shreyaspatil.EasyUpiPayment/EasyUpiPayment?label=mavenCentral)
 ![API](https://img.shields.io/badge/API-19%2B-brightgreen.svg)
 
 ### [Visit official documentation for the details](https://eupipay-docs.netlify.app/)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'com.google.android.material:material:1.2.1'
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
     // EasyUpiPayment Library
-    implementation 'dev.shreyaspatil.EasyUpiPayment:EasyUpiPayment:3.0.2'
+    implementation 'dev.shreyaspatil.EasyUpiPayment:EasyUpiPayment:3.0.3'
 
 //    implementation project(path: ':EasyUpiPayment')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath 'com.vanniktech:gradle-maven-publish-plugin:0.14.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.4.30")

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.14.1'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.16.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.4.30")
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Easy UPI Payment - Android Library
 
-![Bintray](https://img.shields.io/bintray/v/patilshreyas/maven/com.shreyaspatil:EasyUpiPayment?style=flat-square)
+![Maven Central](https://img.shields.io/maven-central/v/dev.shreyaspatil.EasyUpiPayment/EasyUpiPayment?label=mavenCentral)
 ![API](https://img.shields.io/badge/API-19%2B-brightgreen.svg)
 ![Github Followers](https://img.shields.io/github/followers/PatilShreyas?label=Follow&style=square)
 ![GitHub stars](https://img.shields.io/github/stars/PatilShreyas/EasyUpiPayment-Android?style=square)

--- a/docs/pages/changelog.md
+++ b/docs/pages/changelog.md
@@ -4,6 +4,14 @@ You can see [GitHub releases](https://github.com/PatilShreyas/EasyUpiPayment-And
 
 ---
 
+## _v3.0.3_ (2021-06-29)
+
+This release includes patch fixes.
+
+- Provided `<query>` in library Manifest for intent and specific UPI packages to support devices having _Android 11 and Above_.
+- Fix `ActivityNotFoundException` crash occurring on Android 11 devices due to missing query intents.
+
+
 ## _v3.0.2_ (2021-03-18)
 This release includes minor additions.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ android.enableJetifier=true
 # Maven Publish Details
 GROUP=dev.shreyaspatil.EasyUpiPayment
 POM_ARTIFACT_ID=EasyUpiPayment
-VERSION_NAME=3.0.2
+VERSION_NAME=3.0.3
 POM_NAME=EasyUpiPayment-Android
 POM_DESCRIPTION=Android Library to integrate UPI payment service easily in your Android app.
 POM_INCEPTION_YEAR=2021

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
## Summary

Patch release.

Android 11 has introduced package visibility for querying packages. That's why it's crashing on those devices due to `ActivityNotFoundException`. Now, we have declared the needed components in the manifest for querying packages. Thus, it fixes issues.

Fixes: #115, #112, #97, #89